### PR TITLE
Build Docker images for arm64

### DIFF
--- a/.github/workflows/image-on-push.yaml
+++ b/.github/workflows/image-on-push.yaml
@@ -39,5 +39,6 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}


### PR DESCRIPTION
I can't really test this, but I think this is the change per my perusal of: https://docs.docker.com/build/ci/github-actions/multi-platform/

I've noticed that when I pull owl-shot on my arm64 machines, I always get `requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8)` errors.